### PR TITLE
Fix R5C0 startup after JTAG boot with one-time remoteproc normalization

### DIFF
--- a/recipes-bsp/zuboard-firmware/files/msys
+++ b/recipes-bsp/zuboard-firmware/files/msys
@@ -21,6 +21,7 @@ FW_SRC="${MSYS_FW_SRC:-/opt/monutchee/msys/firmware}"
 FW_DST="${MSYS_FW_DST:-/lib/firmware}"
 FPGA_MGR="${MSYS_FPGA_MGR:-/sys/class/fpga_manager/fpga0}"
 RPROC_BASE="${MSYS_RPROC_BASE:-/sys/class/remoteproc}"
+STATE_DIR="${MSYS_STATE_DIR:-/run/msys}"
 
 err()  { printf '%s: error: %s\n' "$PROG" "$*" >&2; }
 die()  { err "$*"; exit 1; }
@@ -76,6 +77,54 @@ rproc_dir() {
 
 is_rproc() { case "$1" in r5c0|r5c1) return 0 ;; *) return 1 ;; esac; }
 
+wait_rproc_state() {
+    rp=$1
+    expected=$2
+    attempts=5
+
+    while [ "$attempts" -gt 0 ]; do
+        [ "$(cat "$rp/state" 2>/dev/null)" = "$expected" ] && return 0
+        attempts=$((attempts - 1))
+        sleep 1
+    done
+    return 1
+}
+
+stop_rproc() {
+    target=$1
+    rp=$2
+
+    printf 'stop\n' > "$rp/state" || die "failed to stop $target"
+    wait_rproc_state "$rp" offline || die "$target did not reach offline state"
+}
+
+# R5C0 needs one complete remoteproc start/stop cycle after each system boot.
+# A stop cannot be issued while remoteproc is offline, so perform the valid
+# load/start/stop sequence once and remember it in the volatile /run tree.
+normalize_r5c0() {
+    rp=$1
+    file=$2
+    marker="$STATE_DIR/r5c0-normalized"
+
+    [ -e "$marker" ] && return
+    [ "$(cat "$FPGA_MGR/state" 2>/dev/null)" = operating ] ||
+        die "FPGA must be loaded before loading r5c0"
+
+    if [ "$(cat "$rp/state" 2>/dev/null)" = running ]; then
+        info "r5c0 is running; stopping before reload"
+        stop_rproc r5c0 "$rp"
+    else
+        printf '%s\n' "$file" > "$rp/firmware" || die "failed to set firmware for r5c0"
+        info "normalizing r5c0 remoteproc state"
+        printf 'start\n' > "$rp/state" || die "failed to start r5c0 during normalization"
+        wait_rproc_state "$rp" running || die "r5c0 did not start during normalization"
+        stop_rproc r5c0 "$rp"
+    fi
+
+    mkdir -p "$STATE_DIR" || die "failed to create $STATE_DIR"
+    : > "$marker" || die "failed to record r5c0 normalization"
+}
+
 # Resolve a requested target into a concrete list. For 'all', only include
 # targets that are actually present for the given command (so a not-yet-released
 # r5c1 is silently skipped instead of erroring).
@@ -124,10 +173,13 @@ do_load() {
     else
         rp=$(rproc_dir "$1")
         [ -d "$rp" ] || die "remoteproc for $1 not found at $rp"
+        if [ "$1" = r5c0 ]; then
+            normalize_r5c0 "$rp" "$file"
+        fi
         # remoteproc only accepts a new firmware name while offline.
         if [ "$(cat "$rp/state" 2>/dev/null)" = running ]; then
             info "$1 is running; stopping before reload"
-            printf 'stop\n' > "$rp/state" || die "failed to stop $1"
+            stop_rproc "$1" "$rp"
         fi
         printf '%s\n' "$file" > "$rp/firmware" || die "failed to set firmware for $1"
         info "loaded $file on $1 (run '$PROG start $1' to execute)"
@@ -139,7 +191,12 @@ do_start() {
     is_rproc "$1" || die "'start' applies to r5c0/r5c1 only (the FPGA runs on load)"
     rp=$(rproc_dir "$1")
     [ -d "$rp" ] || die "remoteproc for $1 not found at $rp"
+    if [ "$(cat "$rp/state" 2>/dev/null)" = running ]; then
+        info "$1 is already running"
+        return
+    fi
     printf 'start\n' > "$rp/state" || die "failed to start $1"
+    wait_rproc_state "$rp" running || die "$1 did not reach running state"
     info "$1 started"
 }
 
@@ -148,7 +205,11 @@ do_stop() {
     is_rproc "$1" || die "'stop' applies to r5c0/r5c1 only"
     rp=$(rproc_dir "$1")
     [ -d "$rp" ] || die "remoteproc for $1 not found at $rp"
-    printf 'stop\n' > "$rp/state" || die "failed to stop $1"
+    if [ "$(cat "$rp/state" 2>/dev/null)" = offline ]; then
+        info "$1 is already stopped"
+        return
+    fi
+    stop_rproc "$1" "$rp"
     info "$1 stopped"
 }
 


### PR DESCRIPTION

## Problem

After a JTAG boot, R5C0 does not function when started normally:

```sh
msys install all && msys load all && msys start all
```

R5C1 starts correctly. Linux reports R5C0 as `running`, but its firmware does not operate as expected.

## Findings

- Loading the R5C0 firmware twice before starting does not help.
- Starting R5C0 twice without stopping does not help.
- R5C0 works after this sequence:

```text
load -> start -> load -> start
```

- `msys load r5c0` stops the core when it is running, so the effective recovery sequence is:

```text
load -> start -> stop -> load -> start
```

- Writing `stop` while remoteproc is `offline` fails with `EINVAL`.
- FPGA programming must occur before any R5 firmware runs because both R5 applications access AXI GPIO.
- R5C1 does not require this recovery sequence.
- The remoteproc log reports a successful first boot even when the R5C0 application is not functioning.

## Estimated Root Cause

The precise hardware-level cause has not yet been proven.

The evidence suggests that R5C0 is not fully initialized or reset during its first remoteproc start after a JTAG boot. The likely source is stale R5C0 processor, firmware startup, or Xilinx power-management state.

This is not a firmware file loading failure because remoteproc successfully loads the ELF and reports the processor as running. An explicit stop followed by another start resets enough R5C0 state for the application to operate correctly.

Resetting the R5 cores before starting PMUFW was also tested, but it did not resolve the issue.

## Workaround

`msys load r5c0` now performs a one-time normalization sequence per Linux boot:

```text
load R5C0
start R5C0
stop R5C0
leave R5C0 loaded and offline
```

The subsequent normal `msys start r5c0` performs the working second start.

A marker under `/run/msys` prevents the normalization sequence from being repeated unnecessarily. Because `/run` is volatile, the sequence is performed again after each reboot.

The command interface remains unchanged:

```sh
msys install all && msys load all && msys start all
```

The workaround also verifies that the FPGA is operating before temporarily starting R5C0.

## Additional Improvements

- Wait for remoteproc to reach the requested `running` or `offline` state.
- Treat repeated start and stop operations as idempotent.
- Report errors when a requested state transition does not complete.

## Verification

The updated image was tested after a fresh JTAG boot using:

```sh
xsdb load-jtag-image.tcl 172.30.19.20 172.30.19.19
```

The complete command succeeded:

```sh
msys install all && msys load all && msys start all
```

The kernel log confirmed:

```text
R5C0 start
R5C0 stop
R5C0 start
R5C1 start
```

Both R5 cores then reported the `running` state.