### PR TITLE
Fix repeated JTAG boot on the ZuBoard without requiring a manual reset, and remove the obsolete R5C0 remoteproc workaround.

### DIFF
--- a/README
+++ b/README
@@ -105,3 +105,18 @@ cannot select exactly one device.
 The board device tree must enable the eMMC controller and expose its user-area
 block device to Linux. The current zub1cg.dtsi explicitly enables only sdhci1
 for the SD card, so eMMC pinmux/controller support is still a board prerequisite.
+
+
+
+# Looad the fpga and the R5 cores
+
+## New method
+
+```
+msys install all && msys load all && msys start all
+```
+
+## Old and base method
+```
+msys install all && echo fpga.bit > /sys/class/fpga_manager/fpga0/firmware && echo r5c0.elf > /sys/class/remoteproc/remoteproc0/firmware && echo start > /sys/class/remoteproc/remoteproc0/state && echo r5c1.elf > /sys/class/remoteproc/remoteproc1/firmware && echo start > /sys/class/remoteproc/remoteproc1/state
+```

--- a/recipes-bsp/zuboard-firmware/files/msys
+++ b/recipes-bsp/zuboard-firmware/files/msys
@@ -21,7 +21,6 @@ FW_SRC="${MSYS_FW_SRC:-/opt/monutchee/msys/firmware}"
 FW_DST="${MSYS_FW_DST:-/lib/firmware}"
 FPGA_MGR="${MSYS_FPGA_MGR:-/sys/class/fpga_manager/fpga0}"
 RPROC_BASE="${MSYS_RPROC_BASE:-/sys/class/remoteproc}"
-STATE_DIR="${MSYS_STATE_DIR:-/run/msys}"
 
 err()  { printf '%s: error: %s\n' "$PROG" "$*" >&2; }
 die()  { err "$*"; exit 1; }
@@ -98,33 +97,6 @@ stop_rproc() {
     wait_rproc_state "$rp" offline || die "$target did not reach offline state"
 }
 
-# R5C0 needs one complete remoteproc start/stop cycle after each system boot.
-# A stop cannot be issued while remoteproc is offline, so perform the valid
-# load/start/stop sequence once and remember it in the volatile /run tree.
-normalize_r5c0() {
-    rp=$1
-    file=$2
-    marker="$STATE_DIR/r5c0-normalized"
-
-    [ -e "$marker" ] && return
-    [ "$(cat "$FPGA_MGR/state" 2>/dev/null)" = operating ] ||
-        die "FPGA must be loaded before loading r5c0"
-
-    if [ "$(cat "$rp/state" 2>/dev/null)" = running ]; then
-        info "r5c0 is running; stopping before reload"
-        stop_rproc r5c0 "$rp"
-    else
-        printf '%s\n' "$file" > "$rp/firmware" || die "failed to set firmware for r5c0"
-        info "normalizing r5c0 remoteproc state"
-        printf 'start\n' > "$rp/state" || die "failed to start r5c0 during normalization"
-        wait_rproc_state "$rp" running || die "r5c0 did not start during normalization"
-        stop_rproc r5c0 "$rp"
-    fi
-
-    mkdir -p "$STATE_DIR" || die "failed to create $STATE_DIR"
-    : > "$marker" || die "failed to record r5c0 normalization"
-}
-
 # Resolve a requested target into a concrete list. For 'all', only include
 # targets that are actually present for the given command (so a not-yet-released
 # r5c1 is silently skipped instead of erroring).
@@ -173,9 +145,6 @@ do_load() {
     else
         rp=$(rproc_dir "$1")
         [ -d "$rp" ] || die "remoteproc for $1 not found at $rp"
-        if [ "$1" = r5c0 ]; then
-            normalize_r5c0 "$rp" "$file"
-        fi
         # remoteproc only accepts a new firmware name while offline.
         if [ "$(cat "$rp/state" 2>/dev/null)" = running ]; then
             info "$1 is running; stopping before reload"

--- a/recipes-core/images/files/load-jtag-image.tcl
+++ b/recipes-core/images/files/load-jtag-image.tcl
@@ -9,6 +9,8 @@
 # If board-ip is omitted, U-Boot obtains it through DHCP before loading files.
 # Files fetched by U-Boot are copied to /srv/tftp before JTAG loading starts.
 # Set MNCOS_TFTP_ROOT in the host environment to use a different directory.
+# The loader pulses the board SRST signal through the JTAG cable before using
+# the legacy R5-safe load sequence, then automatically starts its TFTP boot.
 
 proc require_bundle_file {bundle_dir name} {
     set path [file join $bundle_dir $name]
@@ -122,21 +124,24 @@ foreach name {pmufw.elf fsbl.elf tfa.elf u-boot.elf system.dtb} {
 }
 stage_tftp_files $BUNDLE_DIR $TFTP_ROOT
 
+
+#------------------  Xilinx JTAG Flashing Procedure -------------------------------------------------------
+
 puts "Connecting to the Xilinx hw_server"
 connect -url tcp:$HW_IP:3121
 
+# Pulse the board reset signal instead of using the debugger's rst -system.
+# Reconnect afterward so the known-good loader starts with fresh target data.
 targets -set -nocase -filter {name =~ "*PSU*"}
-
-# A processor-only reset leaves clocks, DDR, GIC and peripheral state from the
-# previous Linux session intact. Reset the complete ZynqMP system first so a
-# repeated JTAG boot starts from the same state as a fresh board reset.
-puts "Resetting ZynqMP system"
-if { [catch {rst -system -stop} message] } {
-    error "Could not reset the ZynqMP system: $message"
+puts "Pulsing board SRST through the JTAG cable"
+if { [catch {rst -srst} message] } {
+    error "Could not pulse cable SRST: $message"
 }
-after 1000
+after 2000
+disconnect
+connect -url tcp:$HW_IP:3121
 
-# The reset can refresh the target contexts and closes the JTAG security gates.
+# Select the refreshed PSU target and open the JTAG security gates.
 targets -set -nocase -filter {name =~ "*PSU*"}
 mask_write 0xFFCA0038 0x1C0 0x1C0
 
@@ -148,14 +153,19 @@ dow ./pmufw.elf
 con
 
 targets -set -nocase -filter {name =~ "*A53*#0"}
-puts "Resetting A53 processor before FSBL"
-rst -processor -clear-registers
+puts "Resetting A53 processor group before FSBL"
+# Reset all A53 cores and their processor-group state. A core-only reset can
+# leave the other Linux cores or shared APU state active, causing EDITR/cache
+# timeouts on a repeated JTAG load. This does not reset the separate RPU group.
+rst -cores -clear-registers
 after 500
 
 puts "Downloading FSBL"
 dow ./fsbl.elf
 con
-after 500
+# Match the Xilinx ZynqMP JTAG boot flow and allow FSBL initialization to
+# complete before halting the A53 for the next-stage downloads.
+after 4000
 stop
 
 puts "Downloading TF-A"
@@ -167,15 +177,10 @@ stop
 dow -data ./system.dtb 0x100000
 after 500
 
-# Pass the selected network mode to U-Boot as a text environment block. When
-# BOARD_IP is empty, U-Boot runs DHCP with autoload disabled and then restores
-# the requested TFTP server address before loading files.
+# Pass the selected network mode to U-Boot as a text environment block.
+# U-Boot consumes these values before boot.scr reuses this DDR area.
 download_env_override $SERVER_IP $BOARD_IP 0x20000100
 mwr 0x20000004 0x49504f56
-
-# MNCOS_JTAG_MAGIC ("MNCP"). U-Boot consumes and clears this marker during
-# preboot, imports the optional addresses above, then runs tftpbootstep. This
-# memory is reused by boot.scr after the import is complete.
 mwr 0x20000000 0x4d4e4350
 
 puts "Downloading U-Boot"


### PR DESCRIPTION
## Changes

- Replace `rst -system -stop` with the JTAG cable’s physical `rst -srst`.
- Reconnect to `hw_server` after SRST to refresh target contexts.
- Reset the complete A53 processor group before running FSBL.
- Allow 4 seconds for FSBL initialization.
- Preserve automatic U-Boot TFTP boot.
- Remove the R5C0-specific start/stop normalization workaround.
- Make R5C0 and R5C1 use the same firmware workflow:
  - `msys load` stages the firmware.
  - `msys start` starts the core once.
- Document the simplified FPGA and R5 loading command.

## Reason

The debugger-driven system reset left the RPU/PMU in a state that prevented R5C0 firmware from loading correctly. A physical board reset worked, but required pressing the reset button before every JTAG boot.

Using `rst -srst` reproduces the working external reset through the JTAG cable. The previous R5C0 start/stop workaround is therefore no longer required.

## Validation

- Confirmed JTAG cable SRST works on the ZuBoard.
- Confirmed repeated JTAG boot no longer requires pressing the reset button.
- Verified `msys` shell syntax.
- Verified R5C0 and R5C1 load paths both stage firmware without an implicit start/stop cycle.

## Usage

```sh
msys install all
msys load all
msys start all