### PR TITLE
Rename all related item to zudemo

### DIFF
--- a/README
+++ b/README
@@ -113,10 +113,10 @@ for the SD card, so eMMC pinmux/controller support is still a board prerequisite
 ## New method
 
 ```
-msys install all && msys load all && msys start all
+zud install all && zud load all && zud start all
 ```
 
 ## Old and base method
 ```
-msys install all && echo fpga.bit > /sys/class/fpga_manager/fpga0/firmware && echo r5c0.elf > /sys/class/remoteproc/remoteproc0/firmware && echo start > /sys/class/remoteproc/remoteproc0/state && echo r5c1.elf > /sys/class/remoteproc/remoteproc1/firmware && echo start > /sys/class/remoteproc/remoteproc1/state
+zud install all && echo fpga.bit > /sys/class/fpga_manager/fpga0/firmware && echo r5c0.elf > /sys/class/remoteproc/remoteproc0/firmware && echo start > /sys/class/remoteproc/remoteproc0/state && echo r5c1.elf > /sys/class/remoteproc/remoteproc1/firmware && echo start > /sys/class/remoteproc/remoteproc1/state
 ```

--- a/recipes-bsp/u-boot-xlnx/files/modify_feature.cfg
+++ b/recipes-bsp/u-boot-xlnx/files/modify_feature.cfg
@@ -8,8 +8,8 @@ CONFIG_NVMEM=y
 CONFIG_DM_RTC=y
 
 # Bake extra default-environment vars (e.g. tftpbootstep) into U-Boot.
-# Reads board/xilinx/zynqmp/msys.env, installed by the bbappend.
-CONFIG_ENV_SOURCE_FILE="msys"
+# Reads board/xilinx/zynqmp/zudemo.env, installed by the bbappend.
+CONFIG_ENV_SOURCE_FILE="zudemo"
 
 # Preserve the standard Xilinx preboot initialization, then check whether the
 # dedicated JTAG provisioning loader left its one-shot marker in DDR.

--- a/recipes-bsp/u-boot-xlnx/files/zudemo.env
+++ b/recipes-bsp/u-boot-xlnx/files/zudemo.env
@@ -1,8 +1,8 @@
 /*
- * Custom default U-Boot environment additions for the 'msys' machine.
+ * Custom default U-Boot environment additions for the 'zudemo' machine.
  *
- * Wired in via CONFIG_ENV_SOURCE_FILE="msys" (see modify_feature.cfg) and
- * copied into the U-Boot tree at board/xilinx/zynqmp/msys.env by the
+ * Wired in via CONFIG_ENV_SOURCE_FILE="zudemo" (see modify_feature.cfg) and
+ * copied into the U-Boot tree at board/xilinx/zynqmp/zudemo.env by the
  * u-boot-xlnx bbappend. U-Boot APPENDS these to the standard Xilinx ZynqMP
  * environment rather than replacing it: env_default.h concatenates
  * CONFIG_EXTRA_ENV_TEXT (generated from this file) after the board's

--- a/recipes-bsp/u-boot-xlnx/u-boot-xlnx_%.bbappend
+++ b/recipes-bsp/u-boot-xlnx/u-boot-xlnx_%.bbappend
@@ -1,14 +1,14 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://modify_feature.cfg"
-SRC_URI += "file://msys.env"
+SRC_URI += "file://zudemo.env"
 
 # U-Boot reads its default-environment text from
 #   board/${CONFIG_SYS_VENDOR}/${CONFIG_SYS_BOARD}/<CONFIG_ENV_SOURCE_FILE>.env
-# For this ZynqMP target that resolves to board/xilinx/zynqmp/msys.env, and
-# modify_feature.cfg sets CONFIG_ENV_SOURCE_FILE="msys". Drop the file into the
+# For this ZynqMP target that resolves to board/xilinx/zynqmp/zudemo.env, and
+# modify_feature.cfg sets CONFIG_ENV_SOURCE_FILE="zudemo". Drop the file into the
 # source tree before the environment is generated (do_compile). SRC_URI files
 # are unpacked into ${WORKDIR} on this release (Yocto scarthgap).
 do_configure:prepend() {
-    install -D -m 0644 "${WORKDIR}/msys.env" "${S}/board/xilinx/zynqmp/msys.env"
+    install -D -m 0644 "${WORKDIR}/zudemo.env" "${S}/board/xilinx/zynqmp/zudemo.env"
 }

--- a/recipes-bsp/zuboard-firmware/files/zud
+++ b/recipes-bsp/zuboard-firmware/files/zud
@@ -1,26 +1,26 @@
 #!/bin/sh
-# msys - FPGA / Cortex-R5 firmware management for the msys (ZuBoard) board.
+# zud - FPGA / Cortex-R5 firmware management for the zudemo (ZuBoard) board.
 #
 # Commands:
-#   msys install <fpga|r5c0|r5c1|all>   Copy firmware into the kernel firmware dir
-#   msys load    <fpga|r5c0|r5c1|all>   Hand firmware to fpga_manager / remoteproc
-#   msys start   <r5c0|r5c1|all>        Start a loaded R5 core
-#   msys stop    <r5c0|r5c1|all>        Stop a running R5 core
-#   msys status  [fpga|r5c0|r5c1|all]   Show current state
-#   msys help                           Show this help
+#   zud install <fpga|r5c0|r5c1|all>   Copy firmware into the kernel firmware dir
+#   zud load    <fpga|r5c0|r5c1|all>   Hand firmware to fpga_manager / remoteproc
+#   zud start   <r5c0|r5c1|all>        Start a loaded R5 core
+#   zud stop    <r5c0|r5c1|all>        Stop a running R5 core
+#   zud status  [fpga|r5c0|r5c1|all]   Show current state
+#   zud help                           Show this help
 #
 # The FPGA runs automatically once loaded; R5 cores need an explicit 'start'.
 # POSIX sh (runs under busybox ash and bash) - no bashisms.
 
 set -u
 
-PROG=msys
+PROG=zud
 
 # Paths (overridable via env, mainly for testing).
-FW_SRC="${MSYS_FW_SRC:-/opt/monutchee/msys/firmware}"
-FW_DST="${MSYS_FW_DST:-/lib/firmware}"
-FPGA_MGR="${MSYS_FPGA_MGR:-/sys/class/fpga_manager/fpga0}"
-RPROC_BASE="${MSYS_RPROC_BASE:-/sys/class/remoteproc}"
+FW_SRC="${ZUD_FW_SRC:-/opt/monutchee/zudemo/firmware}"
+FW_DST="${ZUD_FW_DST:-/lib/firmware}"
+FPGA_MGR="${ZUD_FPGA_MGR:-/sys/class/fpga_manager/fpga0}"
+RPROC_BASE="${ZUD_RPROC_BASE:-/sys/class/remoteproc}"
 
 err()  { printf '%s: error: %s\n' "$PROG" "$*" >&2; }
 die()  { err "$*"; exit 1; }

--- a/recipes-bsp/zuboard-firmware/zuboard-firmware_1.0.bb
+++ b/recipes-bsp/zuboard-firmware/zuboard-firmware_1.0.bb
@@ -25,7 +25,7 @@ ZUBOARD_PS_TAG ?= "${ZUBOARD_RELEASE_TAG}"
 ZUBOARD_PL_TAG ?= "${ZUBOARD_RELEASE_TAG}"
 
 # Destination directory on the target rootfs.
-FIRMWARE_INSTALL_DIR ?= "/opt/monutchee/msys/firmware"
+FIRMWARE_INSTALL_DIR ?= "/opt/monutchee/zudemo/firmware"
 
 # -----------------------------------------------------------------------------
 # PS (Cortex-R5) firmware ELFs.
@@ -51,7 +51,7 @@ ZUBOARD_PL_BASEURL = "https://github.com/lesterlo/ZuBoardDemo_PL/releases/downlo
 # The release asset names do not encode the tag, so downloadfilename embeds the
 # tag to keep DL_DIR entries unique (avoids stale-cache checksum errors on bump).
 SRC_URI = "${ZUBOARD_PL_BASEURL}/${ZUBOARD_PL_TAG}/${ZUBOARD_PL_FILE};name=fpga;downloadfilename=zuboard-pl-${ZUBOARD_PL_TAG}-${ZUBOARD_PL_FILE} \
-           file://msys"
+           file://zud"
 
 # Expand one SRC_URI entry per PS ELF listed in ZUBOARD_PS_FILES.
 python () {
@@ -81,16 +81,16 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 INSANE_SKIP:${PN} += "arch ldflags textrel"
 
-# Firmware is board specific: only build for the msys machine, and make the
+# Firmware is board specific: only build for the zudemo machine, and make the
 # package machine-specific so a tag/binary change rebuilds cleanly.
-COMPATIBLE_MACHINE = "^msys$"
+COMPATIBLE_MACHINE = "^zudemo$"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_install() {
     install -d ${D}${FIRMWARE_INSTALL_DIR}
 
     # PS: one ELF per R5 core. Installed under canonical lower-case names
-    # (R5c0.elf -> r5c0.elf) so they match the 'msys' tool and sysfs usage.
+    # (R5c0.elf -> r5c0.elf) so they match the 'zud' tool and sysfs usage.
     for f in ${ZUBOARD_PS_FILES}; do
         dest=$(echo "$f" | tr '[:upper:]' '[:lower:]')
         install -m 0644 ${WORKDIR}/zuboard-ps-${ZUBOARD_PS_TAG}-$f \
@@ -101,9 +101,9 @@ do_install() {
     install -m 0644 ${WORKDIR}/zuboard-pl-${ZUBOARD_PL_TAG}-${ZUBOARD_PL_FILE} \
         ${D}${FIRMWARE_INSTALL_DIR}/${ZUBOARD_PL_FILE}
 
-    # Firmware management CLI -> /usr/bin/msys
+    # Firmware management CLI -> /usr/bin/zud
     install -d ${D}${bindir}
-    install -m 0755 ${WORKDIR}/msys ${D}${bindir}/msys
+    install -m 0755 ${WORKDIR}/zud ${D}${bindir}/zud
 }
 
-FILES:${PN} = "${FIRMWARE_INSTALL_DIR} ${bindir}/msys"
+FILES:${PN} = "${FIRMWARE_INSTALL_DIR} ${bindir}/zud"

--- a/recipes-core/images/mncos-image-minimal.bbappend
+++ b/recipes-core/images/mncos-image-minimal.bbappend
@@ -5,11 +5,11 @@ IMAGE_CLASSES:append = " export-tftpboot-file"
 JTAG_LOADER_TCL = "${ZUBOARD_LAYERDIR}/recipes-core/images/files/load-jtag-image.tcl"
 do_copy_tftpboot[file-checksums] += "${JTAG_LOADER_TCL}:True"
 
-# Board-specific firmware (FPGA bitstream + R5 ELFs) -> /opt/monutchee/firmware.
+# Board-specific firmware (FPGA bitstream + R5 ELFs) -> /opt/monutchee/zud/firmware.
 # Kept here in meta-zuboard so meta-mncos stays a generic, portable OS layer.
-# Scoped to the msys machine so it isn't force-installed if this image is ever
+# Scoped to the zudemo machine so it isn't force-installed if this image is ever
 # built for another processor system while meta-zuboard is layered in.
-IMAGE_INSTALL:append:msys = " zuboard-firmware"
+IMAGE_INSTALL:append:zudemo = " zuboard-firmware"
 
 # (Optional) Change destination directory on machine specific directory
 # TFTPBOOT_DEST_DIR = "${TOPDIR}/export/tftpboot/${MACHINE}"


### PR DESCRIPTION
## Summary
- Rename the ZuBoard Yocto machine references from `msys` to `zudemo`
- Rename the firmware helper executable from `msys` to `zud`
- Move webengine runtime/config paths from `/opt/monutchee/msys` to `/opt/monutchee/mncos`
- Update U-Boot env naming and related docs/comments

## Testing
- Ran `bitbake -p`
- Ran `bitbake webengine -c install`
- Ran `bitbake webengine -c package`
- Confirmed the rootfs no longer contains `/opt/monutchee/msys`